### PR TITLE
Create tests for MinSetCover policies

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,3 +9,4 @@ macro(create_test TestFileName)
 endmacro(create_test)
 
 create_test("EvaluatorTest.cpp")
+create_test("MinSetCoverTest.cpp")

--- a/test/MinSetCoverTest.cpp
+++ b/test/MinSetCoverTest.cpp
@@ -13,10 +13,9 @@ struct E {};
 using U = Universe<A, B, C, D, E>;
 
 using ABCDE = U::Set<A, B, C, D, E>;
-using AB = U::Set<A, B>;
-using BD = U::Set<B, D>;
-using CE = U::Set<C, E>;
-using BE = U::Set<B, E>;
+using ABCD = U::Set<A, B, C, D>;
+using AE = U::Set<A, E>;
+using DE = U::Set<D, E>;
 
 namespace {
 
@@ -33,38 +32,162 @@ auto hasElement() -> decltype(hasElementImpl<tTuple, tElement>(
 
 TEST(MinSetCoverTest, GreedyAndFirstOneWinsTie) {
   using MyMinSetCover = MinSetCover<Greedy<FirstOneWins>>;
-  using Result = decltype(MyMinSetCover::eval<ABCDE, AB, BD, CE, BE>());
-  EXPECT_TRUE(decltype(hasElement<Result, AB>()){});
-  EXPECT_TRUE(decltype(hasElement<Result, BD>()){});
-  EXPECT_TRUE(decltype(hasElement<Result, CE>()){});
-  EXPECT_FALSE(decltype(hasElement<Result, BE>()){});
+  {
+    using Result = decltype(MyMinSetCover::eval<ABCDE, ABCD, AE, DE>());
+    EXPECT_TRUE(decltype(hasElement<Result, ABCD>()){});
+    EXPECT_TRUE(decltype(hasElement<Result, AE>()){});
+    EXPECT_FALSE(decltype(hasElement<Result, DE>()){});
+  }
+  {
+    using Result = decltype(MyMinSetCover::eval<ABCDE, ABCD, DE, AE>());
+    EXPECT_TRUE(decltype(hasElement<Result, ABCD>()){});
+    EXPECT_FALSE(decltype(hasElement<Result, AE>()){});
+    EXPECT_TRUE(decltype(hasElement<Result, DE>()){});
+  }
+  {
+    using Result = decltype(MyMinSetCover::eval<ABCDE, AE, ABCD, DE>());
+    EXPECT_TRUE(decltype(hasElement<Result, ABCD>()){});
+    EXPECT_TRUE(decltype(hasElement<Result, AE>()){});
+    EXPECT_FALSE(decltype(hasElement<Result, DE>()){});
+  }
+  {
+    using Result = decltype(MyMinSetCover::eval<ABCDE, AE, DE, ABCD>());
+    EXPECT_TRUE(decltype(hasElement<Result, ABCD>()){});
+    EXPECT_TRUE(decltype(hasElement<Result, AE>()){});
+    EXPECT_FALSE(decltype(hasElement<Result, DE>()){});
+  }
+  {
+    using Result = decltype(MyMinSetCover::eval<ABCDE, DE, ABCD, AE>());
+    EXPECT_TRUE(decltype(hasElement<Result, ABCD>()){});
+    EXPECT_FALSE(decltype(hasElement<Result, AE>()){});
+    EXPECT_TRUE(decltype(hasElement<Result, DE>()){});
+  }
+  {
+    using Result = decltype(MyMinSetCover::eval<ABCDE, DE, AE, ABCD>());
+    EXPECT_TRUE(decltype(hasElement<Result, ABCD>()){});
+    EXPECT_FALSE(decltype(hasElement<Result, AE>()){});
+    EXPECT_TRUE(decltype(hasElement<Result, DE>()){});
+  }
 }
 
 TEST(MinSetCoverTest, GreedyAndLastOneWinsTie) {
   using MyMinSetCover = MinSetCover<Greedy<LastOneWins>>;
-  using Result = decltype(MyMinSetCover::eval<ABCDE, AB, BD, CE, BE>());
-  EXPECT_TRUE(decltype(hasElement<Result, AB>()){});
-  EXPECT_TRUE(decltype(hasElement<Result, BD>()){});
-  EXPECT_TRUE(decltype(hasElement<Result, CE>()){});
-  EXPECT_TRUE(decltype(hasElement<Result, BE>()){});
+  {
+    using Result = decltype(MyMinSetCover::eval<ABCDE, ABCD, AE, DE>());
+    EXPECT_TRUE(decltype(hasElement<Result, ABCD>()){});
+    EXPECT_FALSE(decltype(hasElement<Result, AE>()){});
+    EXPECT_TRUE(decltype(hasElement<Result, DE>()){});
+  }
+  {
+    using Result = decltype(MyMinSetCover::eval<ABCDE, ABCD, DE, AE>());
+    EXPECT_TRUE(decltype(hasElement<Result, ABCD>()){});
+    EXPECT_TRUE(decltype(hasElement<Result, AE>()){});
+    EXPECT_FALSE(decltype(hasElement<Result, DE>()){});
+  }
+  {
+    using Result = decltype(MyMinSetCover::eval<ABCDE, AE, ABCD, DE>());
+    EXPECT_TRUE(decltype(hasElement<Result, ABCD>()){});
+    EXPECT_FALSE(decltype(hasElement<Result, AE>()){});
+    EXPECT_TRUE(decltype(hasElement<Result, DE>()){});
+  }
+  {
+    using Result = decltype(MyMinSetCover::eval<ABCDE, AE, DE, ABCD>());
+    EXPECT_TRUE(decltype(hasElement<Result, ABCD>()){});
+    EXPECT_FALSE(decltype(hasElement<Result, AE>()){});
+    EXPECT_TRUE(decltype(hasElement<Result, DE>()){});
+  }
+  {
+    using Result = decltype(MyMinSetCover::eval<ABCDE, DE, ABCD, AE>());
+    EXPECT_TRUE(decltype(hasElement<Result, ABCD>()){});
+    EXPECT_TRUE(decltype(hasElement<Result, AE>()){});
+    EXPECT_FALSE(decltype(hasElement<Result, DE>()){});
+  }
+  {
+    using Result = decltype(MyMinSetCover::eval<ABCDE, DE, AE, ABCD>());
+    EXPECT_TRUE(decltype(hasElement<Result, ABCD>()){});
+    EXPECT_TRUE(decltype(hasElement<Result, AE>()){});
+    EXPECT_FALSE(decltype(hasElement<Result, DE>()){});
+  }
 }
 
-using ABCD = U::Set<A, B, C, D>;
-using DE = U::Set<D, E>;
-using _E = U::Set<E>;
+using CDE = U::Set<C, D, E>;
 
 TEST(MinSetCoverTest, GreedyAndTightestOneWinsTie) {
   using MyMinSetCover = MinSetCover<Greedy<TightestOneWins>>;
-  using Result = decltype(MyMinSetCover::eval<ABCDE, ABCD, DE, _E>());
-  EXPECT_TRUE(decltype(hasElement<Result, ABCD>()){});
-  EXPECT_FALSE(decltype(hasElement<Result, DE>()){});
-  EXPECT_TRUE(decltype(hasElement<Result, _E>()){});
+  {
+    using Result = decltype(MyMinSetCover::eval<ABCDE, ABCD, CDE, DE>());
+    EXPECT_TRUE(decltype(hasElement<Result, ABCD>()){});
+    EXPECT_FALSE(decltype(hasElement<Result, CDE>()){});
+    EXPECT_TRUE(decltype(hasElement<Result, DE>()){});
+  }
+  {
+    using Result = decltype(MyMinSetCover::eval<ABCDE, ABCD, DE, CDE>());
+    EXPECT_TRUE(decltype(hasElement<Result, ABCD>()){});
+    EXPECT_FALSE(decltype(hasElement<Result, CDE>()){});
+    EXPECT_TRUE(decltype(hasElement<Result, DE>()){});
+  }
+  {
+    using Result = decltype(MyMinSetCover::eval<ABCDE, CDE, ABCD, DE>());
+    EXPECT_TRUE(decltype(hasElement<Result, ABCD>()){});
+    EXPECT_FALSE(decltype(hasElement<Result, CDE>()){});
+    EXPECT_TRUE(decltype(hasElement<Result, DE>()){});
+  }
+  {
+    using Result = decltype(MyMinSetCover::eval<ABCDE, CDE, DE, ABCD>());
+    EXPECT_TRUE(decltype(hasElement<Result, ABCD>()){});
+    EXPECT_FALSE(decltype(hasElement<Result, CDE>()){});
+    EXPECT_TRUE(decltype(hasElement<Result, DE>()){});
+  }
+  {
+    using Result = decltype(MyMinSetCover::eval<ABCDE, DE, ABCD, CDE>());
+    EXPECT_TRUE(decltype(hasElement<Result, ABCD>()){});
+    EXPECT_FALSE(decltype(hasElement<Result, CDE>()){});
+    EXPECT_TRUE(decltype(hasElement<Result, DE>()){});
+  }
+  {
+    using Result = decltype(MyMinSetCover::eval<ABCDE, DE, CDE, ABCD>());
+    EXPECT_TRUE(decltype(hasElement<Result, ABCD>()){});
+    EXPECT_FALSE(decltype(hasElement<Result, CDE>()){});
+    EXPECT_TRUE(decltype(hasElement<Result, DE>()){});
+  }
 }
 
 TEST(MinSetCoverTest, GreedyAndLoosestOneWinsTie) {
   using MyMinSetCover = MinSetCover<Greedy<LoosestOneWins>>;
-  using Result = decltype(MyMinSetCover::eval<ABCDE, ABCD, DE, _E>());
-  EXPECT_TRUE(decltype(hasElement<Result, ABCD>()){});
-  EXPECT_TRUE(decltype(hasElement<Result, DE>()){});
-  EXPECT_FALSE(decltype(hasElement<Result, _E>()){});
+  {
+    using Result = decltype(MyMinSetCover::eval<ABCDE, ABCD, CDE, DE>());
+    EXPECT_TRUE(decltype(hasElement<Result, ABCD>()){});
+    EXPECT_TRUE(decltype(hasElement<Result, CDE>()){});
+    EXPECT_FALSE(decltype(hasElement<Result, DE>()){});
+  }
+  {
+    using Result = decltype(MyMinSetCover::eval<ABCDE, ABCD, DE, CDE>());
+    EXPECT_TRUE(decltype(hasElement<Result, ABCD>()){});
+    EXPECT_TRUE(decltype(hasElement<Result, CDE>()){});
+    EXPECT_FALSE(decltype(hasElement<Result, DE>()){});
+  }
+  {
+    using Result = decltype(MyMinSetCover::eval<ABCDE, CDE, ABCD, DE>());
+    EXPECT_TRUE(decltype(hasElement<Result, ABCD>()){});
+    EXPECT_TRUE(decltype(hasElement<Result, CDE>()){});
+    EXPECT_FALSE(decltype(hasElement<Result, DE>()){});
+  }
+  {
+    using Result = decltype(MyMinSetCover::eval<ABCDE, CDE, DE, ABCD>());
+    EXPECT_TRUE(decltype(hasElement<Result, ABCD>()){});
+    EXPECT_TRUE(decltype(hasElement<Result, CDE>()){});
+    EXPECT_FALSE(decltype(hasElement<Result, DE>()){});
+  }
+  {
+    using Result = decltype(MyMinSetCover::eval<ABCDE, DE, ABCD, CDE>());
+    EXPECT_TRUE(decltype(hasElement<Result, ABCD>()){});
+    EXPECT_TRUE(decltype(hasElement<Result, CDE>()){});
+    EXPECT_FALSE(decltype(hasElement<Result, DE>()){});
+  }
+  {
+    using Result = decltype(MyMinSetCover::eval<ABCDE, DE, CDE, ABCD>());
+    EXPECT_TRUE(decltype(hasElement<Result, ABCD>()){});
+    EXPECT_TRUE(decltype(hasElement<Result, CDE>()){});
+    EXPECT_FALSE(decltype(hasElement<Result, DE>()){});
+  }
 }

--- a/test/MinSetCoverTest.cpp
+++ b/test/MinSetCoverTest.cpp
@@ -1,0 +1,70 @@
+#include <BoolPack.h>
+#include <MinSetCover.h>
+#include <gtest/gtest.h>
+
+using namespace set_cover;
+
+struct A {};
+struct B {};
+struct C {};
+struct D {};
+struct E {};
+
+using U = Universe<A, B, C, D, E>;
+
+using ABCDE = U::Set<A, B, C, D, E>;
+using AB = U::Set<A, B>;
+using BD = U::Set<B, D>;
+using CE = U::Set<C, E>;
+using BE = U::Set<B, E>;
+
+namespace {
+
+template <typename tTuple, typename tElement, std::size_t... tIndices>
+auto hasElementImpl(std::index_sequence<tIndices...>) -> decltype(anyOf(
+    BoolPack<std::is_same_v<std::tuple_element_t<tIndices, tTuple>,
+                            tElement>...>{}));
+
+template <typename tTuple, typename tElement>
+auto hasElement() -> decltype(hasElementImpl<tTuple, tElement>(
+    std::make_index_sequence<std::tuple_size_v<tTuple>>{}));
+
+} // namespace
+
+TEST(MinSetCoverTest, GreedyAndFirstOneWinsTie) {
+  using MyMinSetCover = MinSetCover<Greedy<FirstOneWins>>;
+  using Result = decltype(MyMinSetCover::eval<ABCDE, AB, BD, CE, BE>());
+  EXPECT_TRUE(decltype(hasElement<Result, AB>()){});
+  EXPECT_TRUE(decltype(hasElement<Result, BD>()){});
+  EXPECT_TRUE(decltype(hasElement<Result, CE>()){});
+  EXPECT_FALSE(decltype(hasElement<Result, BE>()){});
+}
+
+TEST(MinSetCoverTest, GreedyAndLastOneWinsTie) {
+  using MyMinSetCover = MinSetCover<Greedy<LastOneWins>>;
+  using Result = decltype(MyMinSetCover::eval<ABCDE, AB, BD, CE, BE>());
+  EXPECT_TRUE(decltype(hasElement<Result, AB>()){});
+  EXPECT_TRUE(decltype(hasElement<Result, BD>()){});
+  EXPECT_TRUE(decltype(hasElement<Result, CE>()){});
+  EXPECT_TRUE(decltype(hasElement<Result, BE>()){});
+}
+
+using ABCD = U::Set<A, B, C, D>;
+using DE = U::Set<D, E>;
+using _E = U::Set<E>;
+
+TEST(MinSetCoverTest, GreedyAndTightestOneWinsTie) {
+  using MyMinSetCover = MinSetCover<Greedy<TightestOneWins>>;
+  using Result = decltype(MyMinSetCover::eval<ABCDE, ABCD, DE, _E>());
+  EXPECT_TRUE(decltype(hasElement<Result, ABCD>()){});
+  EXPECT_FALSE(decltype(hasElement<Result, DE>()){});
+  EXPECT_TRUE(decltype(hasElement<Result, _E>()){});
+}
+
+TEST(MinSetCoverTest, GreedyAndLoosestOneWinsTie) {
+  using MyMinSetCover = MinSetCover<Greedy<LoosestOneWins>>;
+  using Result = decltype(MyMinSetCover::eval<ABCDE, ABCD, DE, _E>());
+  EXPECT_TRUE(decltype(hasElement<Result, ABCD>()){});
+  EXPECT_TRUE(decltype(hasElement<Result, DE>()){});
+  EXPECT_FALSE(decltype(hasElement<Result, _E>()){});
+}


### PR DESCRIPTION
This PR added a bunch of test cases that exercise MinSetCover template class. The testing code was straightforward to understand, but somewhat verbose. One might like to refactor it to make it more succinct.